### PR TITLE
Discard master and slave terminology

### DIFF
--- a/PI/visualization/MicroView/MicroViewMain.py
+++ b/PI/visualization/MicroView/MicroViewMain.py
@@ -3463,7 +3463,7 @@ class MicroViewMainFrame(wx.Frame, wx.FileDropTarget):
         return 0
 
     def RegSetOrthoCenter(self, position):
-        """Set the ortho center of the slave"""
+        """Set the ortho center of the subordinate"""
         self.pane3D.GetOrthoPlanes().SetOrthoCenter(position)
         self.pane3D.GetRenderWindow().Render()
 

--- a/PI/visualization/MicroView/MicroViewRenderPane.py
+++ b/PI/visualization/MicroView/MicroViewRenderPane.py
@@ -302,7 +302,7 @@ class MicroViewRenderPane(RenderPane.RenderPane):
                 self._stockicons.getMenuBitmap('stock_arrow_%s' % l))
             menu.AppendItem(item)
 
-        self._master.PopupMenu(menu)
+        self._main.PopupMenu(menu)
         menu.Destroy()
 
     def DoCameraZoom(self, evt):
@@ -617,7 +617,7 @@ class MicroViewRenderPane(RenderPane.RenderPane):
 
         try:
             origin = self.GetMicroView().ImageData.GetOrigin()
-            EditingAllowed = self.slave.RegPickPointVol2(x, y, z, origin)
+            EditingAllowed = self.subordinate.RegPickPointVol2(x, y, z, origin)
         except:
             return
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.